### PR TITLE
Typeform integration

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -19,7 +19,8 @@
     "react-stripe-checkout": "^2.6.3",
     "react-stripe-elements": "^2.0.3",
     "react-testing-library": "^5.8.0",
-    "react-typeform-embed": "^0.2.0"
+    "react-typeform-embed": "^0.2.0",
+    "styled-components": "^4.1.3"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -68,7 +68,6 @@ const App = props => {
 
   // add questions
   const addQuestions = question => {
-    console.log('ADDING QUESTIONS');
     axios
       .post('https://refreshr.herokuapp.com/questions', question)
       .then(res => {

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -68,6 +68,7 @@ const App = props => {
 
   // add questions
   const addQuestions = question => {
+    console.log('ADDING QUESTIONS');
     axios
       .post('https://refreshr.herokuapp.com/questions', question)
       .then(res => {

--- a/client/src/components/refreshrs/Refreshr.js
+++ b/client/src/components/refreshrs/Refreshr.js
@@ -71,7 +71,6 @@ function Refreshr(props) {
   `;
 
   const createForm = async event => {
-    console.log('CREATING FORM');
     event.preventDefault();
     const headers = {
       Authorization: `Bearer ${process.env.REACT_APP_TYPEFORM}`

--- a/client/src/components/refreshrs/Refreshr.js
+++ b/client/src/components/refreshrs/Refreshr.js
@@ -71,6 +71,7 @@ function Refreshr(props) {
   `;
 
   const createForm = async event => {
+    console.log('CREATING FORM');
     event.preventDefault();
     const headers = {
       Authorization: `Bearer ${process.env.REACT_APP_TYPEFORM}`
@@ -254,8 +255,10 @@ function Refreshr(props) {
         <Button
           variant="contained"
           color="primary"
-          // onClick={() => props.addQuestions(questionObject)}
-          onClick={e => createForm(e)}
+          onClick={e => {
+            props.addQuestions(questionObject);
+            createForm(e);
+          }}
         >
           Submit
         </Button>

--- a/client/src/components/refreshrs/Refreshr.js
+++ b/client/src/components/refreshrs/Refreshr.js
@@ -108,8 +108,6 @@ function Refreshr(props) {
           headers
         }
       );
-      console.log('RESPONSE ===', response);
-      console.log('URL ==', url);
       setUrl(response.data._links.display);
     } catch (error) {
       console.log(error);
@@ -117,9 +115,6 @@ function Refreshr(props) {
     setSubmitted(true);
   };
 
-  console.log('Question object ===', questionObject);
-  console.log('Submitted final ===>', submitted);
-  console.log('URL', url);
   return (
     <Grid className={props.classes.wrapper}>
       <FormGroup
@@ -132,6 +127,7 @@ function Refreshr(props) {
           })
         }
       >
+        <h2>Create Your Refreshr</h2>
         <TextField
           value={refreshrName}
           label="Refreshr Name"
@@ -145,8 +141,8 @@ function Refreshr(props) {
           }}
           onChange={e => addRefreshrName(e.target.value)}
         />
-        <h4 className={props.classes.subheaders}>Review Text</h4>
-        <TextField
+        {/* <h4 className={props.classes.subheaders}>Review Text</h4> */}
+        {/* <TextField
           value={reviewText}
           label="Review Text"
           name="reviewText"
@@ -156,7 +152,7 @@ function Refreshr(props) {
             shrink: true
           }}
           onChange={e => setReviewText(e.target.value)}
-        />
+        /> */}
         <h4 className={props.classes.subheaders}>Question</h4>
         <TextField
           value={questionText}

--- a/client/src/components/refreshrs/Refreshr.js
+++ b/client/src/components/refreshrs/Refreshr.js
@@ -6,9 +6,7 @@ import FormGroup from '@material-ui/core/FormGroup';
 import Checkbox from '@material-ui/core/Checkbox';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 import Button from '@material-ui/core/Button';
-import { queueScheduler } from 'rxjs';
 import styled from 'styled-components';
-import { NavLink as RouterNavLink } from 'react-router-dom';
 
 const axios = require('axios');
 

--- a/client/src/components/refreshrs/Refreshr.js
+++ b/client/src/components/refreshrs/Refreshr.js
@@ -84,10 +84,13 @@ function Refreshr(props) {
       ]
     };
     try {
-      const response = await axios('https://api.typeform.com/forms', {
-        headers,
-        data
-      });
+      const response = await axios.post(
+        'https://api.typeform.com/forms',
+        data,
+        {
+          headers
+        }
+      );
       console.log('RESPONSE ===', response);
     } catch (error) {
       console.log(error);

--- a/client/src/components/refreshrs/Refreshr.js
+++ b/client/src/components/refreshrs/Refreshr.js
@@ -6,8 +6,11 @@ import FormGroup from '@material-ui/core/FormGroup';
 import Checkbox from '@material-ui/core/Checkbox';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 import Button from '@material-ui/core/Button';
+import { queueScheduler } from 'rxjs';
 
-const styles = (theme) => ({
+const axios = require('axios');
+
+const styles = theme => ({
   wrapper: {
     margin: '2rem auto',
     borderRadius: '0 0 5px 5px',
@@ -59,6 +62,39 @@ function Refreshr(props) {
     answers: { a1Text, a1, a2Text, a2, a3Text, a3, a4Text, a4 }
   });
 
+  const createForm = async event => {
+    event.preventDefault();
+    const headers = {
+      Authorization: 'Bearer A7N7Mxo3cHvRyh7heJ4BErAzHYj4VTTsYT98MD77haXs'
+    };
+    const data = {
+      title: questionObject.refreshrName,
+      fields: [
+        {
+          title: questionObject.reviewText,
+          type: 'multiple_choice',
+          properties: {
+            choices: [
+              {
+                label: questionObject.answers.a1Text
+              }
+            ]
+          }
+        }
+      ]
+    };
+    try {
+      const response = await axios('https://api.typeform.com/forms', {
+        headers,
+        data
+      });
+      console.log('RESPONSE ===', response);
+    } catch (error) {
+      console.log(error);
+    }
+  };
+
+  console.log('Question object ===', questionObject);
   return (
     <Grid className={props.classes.wrapper}>
       <FormGroup
@@ -82,7 +118,7 @@ function Refreshr(props) {
           InputLabelProps={{
             shrink: true
           }}
-          onChange={(e) => addRefreshrName(e.target.value)}
+          onChange={e => addRefreshrName(e.target.value)}
         />
         <h4 className={props.classes.subheaders}>Review Text</h4>
         <TextField
@@ -94,7 +130,7 @@ function Refreshr(props) {
           InputLabelProps={{
             shrink: true
           }}
-          onChange={(e) => setReviewText(e.target.value)}
+          onChange={e => setReviewText(e.target.value)}
         />
         <h4 className={props.classes.subheaders}>Question</h4>
         <TextField
@@ -106,7 +142,7 @@ function Refreshr(props) {
           InputLabelProps={{
             shrink: true
           }}
-          onChange={(e) => setQuestionText(e.target.value)}
+          onChange={e => setQuestionText(e.target.value)}
         />
         <FormGroup className={props.classes.formGroup}>
           <FormControlLabel
@@ -115,7 +151,7 @@ function Refreshr(props) {
                 <Checkbox
                   checked={a1}
                   color="primary"
-                  onChange={(e) => setA1(e.target.checked)}
+                  onChange={e => setA1(e.target.checked)}
                 />
                 <TextField
                   variant="outlined"
@@ -125,7 +161,7 @@ function Refreshr(props) {
                   }}
                   value={a1Text}
                   className={props.classes.answerFields}
-                  onChange={(e) => setA1Text(e.target.value)}
+                  onChange={e => setA1Text(e.target.value)}
                 />
               </>
             }
@@ -136,7 +172,7 @@ function Refreshr(props) {
                 <Checkbox
                   checked={a2}
                   color="primary"
-                  onChange={(e) => setA2(e.target.checked)}
+                  onChange={e => setA2(e.target.checked)}
                 />
                 <TextField
                   variant="outlined"
@@ -146,7 +182,7 @@ function Refreshr(props) {
                   }}
                   value={a2Text}
                   className={props.classes.answerFields}
-                  onChange={(e) => setA2Text(e.target.value)}
+                  onChange={e => setA2Text(e.target.value)}
                 />
               </>
             }
@@ -157,7 +193,7 @@ function Refreshr(props) {
                 <Checkbox
                   checked={a3}
                   color="primary"
-                  onChange={(e) => setA3(e.target.checked)}
+                  onChange={e => setA3(e.target.checked)}
                 />
                 <TextField
                   variant="outlined"
@@ -167,7 +203,7 @@ function Refreshr(props) {
                   }}
                   value={a3Text}
                   className={props.classes.answerFields}
-                  onChange={(e) => setA3Text(e.target.value)}
+                  onChange={e => setA3Text(e.target.value)}
                 />
               </>
             }
@@ -178,7 +214,7 @@ function Refreshr(props) {
                 <Checkbox
                   checked={a4}
                   color="primary"
-                  onChange={(e) => setA4(e.target.checked)}
+                  onChange={e => setA4(e.target.checked)}
                 />
                 <TextField
                   variant="outlined"
@@ -188,7 +224,7 @@ function Refreshr(props) {
                   }}
                   value={a4Text}
                   className={props.classes.answerFields}
-                  onChange={(e) => setA4Text(e.target.value)}
+                  onChange={e => setA4Text(e.target.value)}
                 />
               </>
             }
@@ -197,7 +233,8 @@ function Refreshr(props) {
         <Button
           variant="contained"
           color="primary"
-          onClick={() => props.addQuestions(questionObject)}
+          // onClick={() => props.addQuestions(questionObject)}
+          onClick={e => createForm(e)}
         >
           Submit
         </Button>

--- a/client/src/components/refreshrs/Refreshr.js
+++ b/client/src/components/refreshrs/Refreshr.js
@@ -73,7 +73,7 @@ function Refreshr(props) {
   const createForm = async event => {
     event.preventDefault();
     const headers = {
-      Authorization: 'Bearer A7N7Mxo3cHvRyh7heJ4BErAzHYj4VTTsYT98MD77haXs'
+      Authorization: `Bearer ${process.env.REACT_APP_TYPEFORM}`
     };
     const data = {
       title: questionObject.refreshrName,

--- a/client/src/components/refreshrs/Refreshr.js
+++ b/client/src/components/refreshrs/Refreshr.js
@@ -7,6 +7,8 @@ import Checkbox from '@material-ui/core/Checkbox';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 import Button from '@material-ui/core/Button';
 import { queueScheduler } from 'rxjs';
+import styled from 'styled-components';
+import { NavLink as RouterNavLink } from 'react-router-dom';
 
 const axios = require('axios');
 
@@ -51,6 +53,8 @@ function Refreshr(props) {
   const [a2, setA2] = useState(false);
   const [a3, setA3] = useState(false);
   const [a4, setA4] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
+  const [url, setUrl] = useState('');
   const [a1Text, setA1Text] = useState('');
   const [a2Text, setA2Text] = useState('');
   const [a3Text, setA3Text] = useState('');
@@ -61,6 +65,10 @@ function Refreshr(props) {
     questionText,
     answers: { a1Text, a1, a2Text, a2, a3Text, a3, a4Text, a4 }
   });
+
+  const StyleDisplay = styled.a`
+    ${{ display: submitted ? 'block' : 'none' }}
+  `;
 
   const createForm = async event => {
     event.preventDefault();
@@ -77,6 +85,15 @@ function Refreshr(props) {
             choices: [
               {
                 label: questionObject.answers.a1Text
+              },
+              {
+                label: questionObject.answers.a2Text
+              },
+              {
+                label: questionObject.answers.a3Text
+              },
+              {
+                label: questionObject.answers.a4Text
               }
             ]
           }
@@ -92,12 +109,17 @@ function Refreshr(props) {
         }
       );
       console.log('RESPONSE ===', response);
+      console.log('URL ==', url);
+      setUrl(response.data._links.display);
     } catch (error) {
       console.log(error);
     }
+    setSubmitted(true);
   };
 
   console.log('Question object ===', questionObject);
+  console.log('Submitted final ===>', submitted);
+  console.log('URL', url);
   return (
     <Grid className={props.classes.wrapper}>
       <FormGroup
@@ -241,6 +263,7 @@ function Refreshr(props) {
         >
           Submit
         </Button>
+        <StyleDisplay>View your Refreshr here: {url}</StyleDisplay>
       </FormGroup>
     </Grid>
   );

--- a/client/src/components/typeform/NewTypeform.js
+++ b/client/src/components/typeform/NewTypeform.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import { ReactTypeformEmbed } from 'react-typeform-embed';
+
+const NewTypeform = props => {
+  return (
+    <div>
+      <h1>The New Typeform</h1>
+      <ReactTypeformEmbed url="https://nick971045.typeform.com/to/eaHFcw/" />
+    </div>
+  );
+};
+
+export default NewTypeform;

--- a/client/src/components/typeform/Typeform.js
+++ b/client/src/components/typeform/Typeform.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
+import { ReactTypeformEmbed } from 'react-typeform-embed';
 const axios = require('axios');
-// import { ReactTypeformEmbed } from 'react-typeform-embed';
 
 const data = {
   title: 'Testing from Typeform section of codebase',
@@ -33,19 +33,19 @@ class Typeform extends Component {
     };
   }
 
-  // getForms = async event => {
-  //   event.preventDefault();
-  //   try {
-  //     const response = await axios.get('https://api.typeform.com/forms', {
-  //       headers: {
-  //         Authorization: 'Bearer A7N7Mxo3cHvRyh7heJ4BErAzHYj4VTTsYT98MD77haXs'
-  //       }
-  //     });
-  //     console.log('RESPONSE ===', response);
-  //   } catch (error) {
-  //     console.log(error);
-  //   }
-  // };
+  getForms = async event => {
+    event.preventDefault();
+    try {
+      const response = await axios.get('https://api.typeform.com/forms', {
+        headers: {
+          Authorization: 'Bearer A7N7Mxo3cHvRyh7heJ4BErAzHYj4VTTsYT98MD77haXs'
+        }
+      });
+      console.log('RESPONSE ===', response);
+    } catch (error) {
+      console.log(error);
+    }
+  };
 
   createForm = async event => {
     try {
@@ -62,12 +62,31 @@ class Typeform extends Component {
     }
   };
 
+  getAnalytics = async event => {
+    event.preventDefault();
+    try {
+      const response = await axios.get(
+        'https://api.typeform.com/forms/jGvWqC/responses',
+        {
+          headers: {
+            Authorization: 'Bearer A7N7Mxo3cHvRyh7heJ4BErAzHYj4VTTsYT98MD77haXs'
+          }
+        }
+      );
+      console.log('RESPONSE ===', response);
+    } catch (error) {
+      console.log(error);
+    }
+  };
+
   render() {
     return (
       <div>
         <h1>Get the forms!</h1>
-        {/* <button onClick={this.getForms}>Get Typeforms</button> */}
+        <ReactTypeformEmbed url="https://nick971045.typeform.com/to/eaHFcw/" />
+        <button onClick={this.getForms}>Get Typeforms</button>
         <button onClick={this.createForm}>Create Typeforms</button>
+        <button onClick={this.getAnalytics}>Get getAnalytics</button>
       </div>
     );
   }

--- a/client/src/components/typeform/Typeform.js
+++ b/client/src/components/typeform/Typeform.js
@@ -66,7 +66,7 @@ class Typeform extends Component {
     event.preventDefault();
     try {
       const response = await axios.get(
-        'https://api.typeform.com/forms/jGvWqC/responses',
+        'https://api.typeform.com/forms/hWWX4R/responses',
         {
           headers: {
             Authorization: 'Bearer A7N7Mxo3cHvRyh7heJ4BErAzHYj4VTTsYT98MD77haXs'
@@ -83,7 +83,7 @@ class Typeform extends Component {
     return (
       <div>
         <h1>Get the forms!</h1>
-        <ReactTypeformEmbed url="https://nick971045.typeform.com/to/eaHFcw/" />
+        {/* <ReactTypeformEmbed url="https://nick971045.typeform.com/to/eaHFcw/" /> */}
         <button onClick={this.getForms}>Get Typeforms</button>
         <button onClick={this.createForm}>Create Typeforms</button>
         <button onClick={this.getAnalytics}>Get getAnalytics</button>

--- a/client/src/components/typeform/Typeform.js
+++ b/client/src/components/typeform/Typeform.js
@@ -3,13 +3,13 @@ const axios = require('axios');
 // import { ReactTypeformEmbed } from 'react-typeform-embed';
 
 const data = {
-  title: 'Test from codebase',
+  title: 'Testing from Typeform section of codebase',
   fields: [
     {
-      title: 'the test',
+      title: 'A great test',
       type: 'multiple_choice',
       properties: {
-        description: 'Brilliant questions!',
+        description: 'Fantastic questions!',
         choices: [
           {
             ref: 'Coding coding coding',
@@ -33,26 +33,29 @@ class Typeform extends Component {
     };
   }
 
-  getForms = async event => {
-    event.preventDefault();
-    try {
-      const response = await axios.get('https://api.typeform.com/forms', {
-        headers: {
-          Authorization: 'Bearer A7N7Mxo3cHvRyh7heJ4BErAzHYj4VTTsYT98MD77haXs'
-        }
-      });
-      console.log('RESPONSE ===', response);
-    } catch (error) {
-      console.log(error);
-    }
-  };
+  // getForms = async event => {
+  //   event.preventDefault();
+  //   try {
+  //     const response = await axios.get('https://api.typeform.com/forms', {
+  //       headers: {
+  //         Authorization: 'Bearer A7N7Mxo3cHvRyh7heJ4BErAzHYj4VTTsYT98MD77haXs'
+  //       }
+  //     });
+  //     console.log('RESPONSE ===', response);
+  //   } catch (error) {
+  //     console.log(error);
+  //   }
+  // };
 
   createForm = async event => {
     try {
-      const response = await axios('https://api.typeform.com/forms', {
-        headers,
-        data
-      });
+      const response = await axios.post(
+        'https://api.typeform.com/forms',
+        data,
+        {
+          headers
+        }
+      );
       console.log('RESPONSE ===', response);
     } catch (error) {
       console.log(error);
@@ -63,7 +66,7 @@ class Typeform extends Component {
     return (
       <div>
         <h1>Get the forms!</h1>
-        <button onClick={this.getForms}>Get Typeforms</button>
+        {/* <button onClick={this.getForms}>Get Typeforms</button> */}
         <button onClick={this.createForm}>Create Typeforms</button>
       </div>
     );
@@ -77,7 +80,6 @@ class Typeform extends Component {
 //     <div>
 //       <h1>My Typeform</h1>
 //       {/* <ReactTypeformEmbed url="https://nick971045.typeform.com/to/eaHFcw/" /> */}
-
 //       <button>Get Typeforms</button>
 //     </div>
 //   );

--- a/client/src/components/typeform/Typeform.js
+++ b/client/src/components/typeform/Typeform.js
@@ -22,7 +22,7 @@ const data = {
 };
 
 const headers = {
-  Authorization: 'Bearer A7N7Mxo3cHvRyh7heJ4BErAzHYj4VTTsYT98MD77haXs'
+  Authorization: `Bearer ${process.env.REACT_APP_TYPEFORM}`
 };
 
 class Typeform extends Component {
@@ -38,7 +38,7 @@ class Typeform extends Component {
     try {
       const response = await axios.get('https://api.typeform.com/forms', {
         headers: {
-          Authorization: 'Bearer A7N7Mxo3cHvRyh7heJ4BErAzHYj4VTTsYT98MD77haXs'
+          Authorization: `Bearer ${process.env.REACT_APP_TYPEFORM}`
         }
       });
       console.log('RESPONSE ===', response);
@@ -69,7 +69,7 @@ class Typeform extends Component {
         'https://api.typeform.com/forms/hWWX4R/responses',
         {
           headers: {
-            Authorization: 'Bearer A7N7Mxo3cHvRyh7heJ4BErAzHYj4VTTsYT98MD77haXs'
+            Authorization: `Bearer ${process.env.REACT_APP_TYPEFORM}`
           }
         }
       );

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -806,6 +806,18 @@
   dependencies:
     "@emotion/memoize" "^0.6.6"
 
+"@emotion/is-prop-valid@^0.7.3":
+  version "0.7.3"
+  resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-0.7.3.tgz#a6bf4fa5387cbba59d44e698a4680f481a8da6cc"
+  integrity sha512-uxJqm/sqwXw3YPA5GXX365OBcJGFtxUVkB6WyezqFHlNe9jqUWH5ur2O2M8dGBz61kn1g3ZBlzUunFQXQIClhA==
+  dependencies:
+    "@emotion/memoize" "0.7.1"
+
+"@emotion/memoize@0.7.1":
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.7.1.tgz#e93c13942592cf5ef01aa8297444dc192beee52f"
+  integrity sha512-Qv4LTqO11jepd5Qmlp3M1YEjBumoTHcHFdgPTQ+sFlIL5myi/7xu/POwP7IRu6odBdmLXdtIs1D6TuW6kbwbbg==
+
 "@emotion/memoize@^0.6.1", "@emotion/memoize@^0.6.6":
   version "0.6.6"
   resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.6.6.tgz#004b98298d04c7ca3b4f50ca2035d4f60d2eed1b"
@@ -820,6 +832,11 @@
   version "0.6.7"
   resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.6.7.tgz#53e9f1892f725b194d5e6a1684a7b394df592397"
   integrity sha512-Arj1hncvEVqQ2p7Ega08uHLr1JuRYBuO5cIvcA+WWEQ5+VmkOE3ZXzl04NbQxeQpWX78G7u6MqxKuNX3wvYZxg==
+
+"@emotion/unitless@^0.7.0":
+  version "0.7.3"
+  resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.7.3.tgz#6310a047f12d21a1036fb031317219892440416f"
+  integrity sha512-4zAPlpDEh2VwXswwr/t8xGNDGg8RQiPxtxZ3qQEXyQsBV39ptTdESCjuBvGze1nLMVrxmTIKmnO/nAV8Tqjjzg==
 
 "@material-ui/core@^3.9.2":
   version "3.9.2"
@@ -1778,6 +1795,21 @@ babel-plugin-named-asset-import@^0.3.1:
   resolved "https://registry.yarnpkg.com/babel-plugin-named-asset-import/-/babel-plugin-named-asset-import-0.3.1.tgz#5ec13ec446d0a1e5bb6c57a1f94c9cdedb0c50d6"
   integrity sha512-vzZlo+yEB5YHqI6CRRTDojeT43J3Wf3C/MVkZW5UlbSeIIVUYRKtxaFT2L/VTv9mbIyatCW39+9g/SZolvwRUQ==
 
+"babel-plugin-styled-components@>= 1":
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-styled-components/-/babel-plugin-styled-components-1.10.0.tgz#ff1f42ad2cc78c21f26b62266b8f564dbc862939"
+  integrity sha512-sQVKG8irFXx14ZfaK1bBePirfkacl3j8nZwSZK+ZjsbnadRHKQTbhXbe/RB1vT6Vgkz45E+V95LBq4KqdhZUNw==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.0.0"
+    "@babel/helper-module-imports" "^7.0.0"
+    babel-plugin-syntax-jsx "^6.18.0"
+    lodash "^4.17.10"
+
+babel-plugin-syntax-jsx@^6.18.0:
+  version "6.18.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz#0af32a9a6e13ca7a3fd5069e62d7b0f58d0d8946"
+  integrity sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY=
+
 babel-plugin-syntax-object-rest-spread@^6.13.0, babel-plugin-syntax-object-rest-spread@^6.8.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz#fd6536f2bce13836ffa3a5458c4903a597bb3bf5"
@@ -2239,6 +2271,11 @@ camelcase@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.0.0.tgz#03295527d58bd3cd4aa75363f35b2e8d97be2f42"
   integrity sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA==
+
+camelize@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/camelize/-/camelize-1.0.0.tgz#164a5483e630fa4321e5af07020e531831b2609b"
+  integrity sha1-FkpUg+Yw+kMh5a8HAg5TGDGyYJs=
 
 caniuse-api@^3.0.0:
   version "3.0.0"
@@ -2786,6 +2823,11 @@ css-blank-pseudo@^0.1.4:
   dependencies:
     postcss "^7.0.5"
 
+css-color-keywords@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/css-color-keywords/-/css-color-keywords-1.0.0.tgz#fea2616dc676b2962686b3af8dbdbe180b244e05"
+  integrity sha1-/qJhbcZ2spYmhrOvjb2+GAskTgU=
+
 css-color-names@0.0.4, css-color-names@^0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/css-color-names/-/css-color-names-0.0.4.tgz#808adc2e79cf84738069b646cb20ec27beb629e0"
@@ -2865,6 +2907,15 @@ css-selector-tokenizer@^0.7.0:
     cssesc "^0.1.0"
     fastparse "^1.1.1"
     regexpu-core "^1.0.0"
+
+css-to-react-native@^2.2.2:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/css-to-react-native/-/css-to-react-native-2.3.0.tgz#bf80d24ec4a08e430306ef429c0586e6ed5485f7"
+  integrity sha512-IhR7bNIrCFwbJbKZOAjNDZdwpsbjTN6f1agXeELHDqg1wHPA8c2QLruttKOW7hgMGetkfraRJCIEMrptifBfVw==
+  dependencies:
+    camelize "^1.0.0"
+    css-color-keywords "^1.0.0"
+    postcss-value-parser "^3.3.0"
 
 css-tree@1.0.0-alpha.28:
   version "1.0.0-alpha.28"
@@ -6455,6 +6506,11 @@ mem@^4.0.0:
     mimic-fn "^1.0.0"
     p-is-promise "^2.0.0"
 
+memoize-one@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-4.1.0.tgz#a2387c58c03fff27ca390c31b764a79addf3f906"
+  integrity sha512-2GApq0yI/b22J2j9rhbrAlsHb0Qcz+7yWxeLG8h+95sl1XPUgeLimQSOdur4Vw7cUhrBHwaUZxWFZueojqNRzA==
+
 memory-fs@^0.4.0, memory-fs@~0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/memory-fs/-/memory-fs-0.4.1.tgz#3a9a20b8462523e447cfbc7e8bb80ed667bfc552"
@@ -8225,7 +8281,7 @@ prompts@^0.1.9:
     kleur "^2.0.1"
     sisteransi "^0.1.1"
 
-prop-types@^15.5.10, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2:
+prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -8466,6 +8522,11 @@ react-event-listener@^0.6.2:
     "@babel/runtime" "^7.2.0"
     prop-types "^15.6.0"
     warning "^4.0.1"
+
+react-is@^16.6.0:
+  version "16.8.3"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.3.tgz#4ad8b029c2a718fc0cfc746c8d4e1b7221e5387d"
+  integrity sha512-Y4rC1ZJmsxxkkPuMLwvKvlL1Zfpbcu+Bf4ZigkHup3v9EfdYhAlWAaVyA19olXq2o2mGn0w+dFKvk3pVVlYcIA==
 
 react-is@^16.6.3, react-is@^16.7.0, react-is@^16.8.1:
   version "16.8.2"
@@ -9693,6 +9754,23 @@ style-loader@0.23.1:
     loader-utils "^1.1.0"
     schema-utils "^1.0.0"
 
+styled-components@^4.1.3:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-4.1.3.tgz#4472447208e618b57e84deaaeb6acd34a5e0fe9b"
+  integrity sha512-0quV4KnSfvq5iMtT0RzpMGl/Dg3XIxIxOl9eJpiqiq4SrAmR1l1DLzNpMzoy3DyzdXVDMJS2HzROnXscWA3SEw==
+  dependencies:
+    "@babel/helper-module-imports" "^7.0.0"
+    "@emotion/is-prop-valid" "^0.7.3"
+    "@emotion/unitless" "^0.7.0"
+    babel-plugin-styled-components ">= 1"
+    css-to-react-native "^2.2.2"
+    memoize-one "^4.0.0"
+    prop-types "^15.5.4"
+    react-is "^16.6.0"
+    stylis "^3.5.0"
+    stylis-rule-sheet "^0.0.10"
+    supports-color "^5.5.0"
+
 stylehacks@^4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/stylehacks/-/stylehacks-4.0.3.tgz#6718fcaf4d1e07d8a1318690881e8d96726a71d5"
@@ -9740,7 +9818,7 @@ supports-color@^3.1.2:
   dependencies:
     has-flag "^1.0.0"
 
-supports-color@^5.1.0, supports-color@^5.3.0, supports-color@^5.4.0:
+supports-color@^5.1.0, supports-color@^5.3.0, supports-color@^5.4.0, supports-color@^5.5.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
   integrity sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==


### PR DESCRIPTION
- V1 Typeform integration. Able to use the info inputted in Refreshr.js to programmatically create a Typeform
- The newly created form URL is then displayed after submitting the form
- `/typeform` is currently a test route I'm using for axios calls. `getAnalytics` retrieves the data from a specified Typeform id

To do:
- Decide how we will render only the Typeforms that a teacher has created to that teacher
- Add correct answer logic
- Ability to create more than 1 multiple choice question
- Ability to create questions with text answers
- On submit should either send the user to their newly created Typeform or to the Classes page
- Remove / update Typeform.js
- Add additional Typeform functionality, e.g. themes
- Analytics page