### PR TITLE
Filters out triplicate classes

### DIFF
--- a/server/routes/teachersRoutes.js
+++ b/server/routes/teachersRoutes.js
@@ -95,7 +95,17 @@ router.get('/:id/classes', jwtCheck, async (req, res, next) => {
   const { id } = req.params;
   try {
     const results = await db.getTeacherDetails(id);
-    res.status(responseStatus.success).json({ classes: results.classes });
+    const classes = results.classes;
+    const uniqueClasses = [];
+    const uniqueIds = [];
+    // filter out unique classes, otherwise we'll get three of each
+    for (let c of classes) {
+      if (!uniqueIds.includes(c.class_id)) {
+        uniqueIds.push(c.class_id);
+        uniqueClasses.push(c);
+      }
+    }
+    res.status(responseStatus.success).json({ classes: uniqueClasses });
   } catch (err) {
     if (TypeError) {
       console.log(err);


### PR DESCRIPTION
Can't imagine there's anywhere we would want all three displayed, but if
there is we could move this to the dashboard

Before: 

![before_filter](https://user-images.githubusercontent.com/13543632/54241745-6941aa00-44f8-11e9-8dbe-a8f42ceae955.png)

After:
![after_filter](https://user-images.githubusercontent.com/13543632/54241756-6f378b00-44f8-11e9-88f0-97c254894500.png)
